### PR TITLE
Adding the option for matplotlib image transparency

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -141,6 +141,12 @@ Then blocks will be sent automatically when a traceback is detected in the respo
   (ob-python-extras-load-alerts))
 #+end_src
 
+** Matplotlib image transparency
+Matplotlib is configured to save and display transparent images by default. The
+default can be changed with ~(setq ob-python-extras/transparent-images nil)~.
+The default, in turn, can be overriden at the org-src-block level with
+=:transparent nil= or =:transparent t=.
+
 * Examples:
 [[file:tests/babel-formatting.org][See this org file for examples of the different functionality and configurations.]]
 

--- a/Readme.org
+++ b/Readme.org
@@ -144,7 +144,7 @@ Then blocks will be sent automatically when a traceback is detected in the respo
 ** Matplotlib image transparency
 Matplotlib is configured to save and display transparent images by default. The
 default can be changed with ~(setq ob-python-extras/transparent-images nil)~.
-The default, in turn, can be overriden at the org-src-block level with
+The default, in turn, can be overridden at the org-src-block level with
 =:transparent nil= or =:transparent t=.
 
 * Examples:

--- a/Readme.org
+++ b/Readme.org
@@ -142,10 +142,11 @@ Then blocks will be sent automatically when a traceback is detected in the respo
 #+end_src
 
 ** Matplotlib image transparency
-Matplotlib is configured to save and display transparent images by default. The
-default can be changed with ~(setq ob-python-extras/transparent-images nil)~.
-The default, in turn, can be overridden at the org-src-block level with
-=:transparent nil= or =:transparent t=.
+Matplotlib is configured to save and display images without transparency by
+default. The default can be changed with ~(setq
+ob-python-extras/transparent-images t)~. This default, in turn, can be
+overridden at the org-src-block level with =:transparent nil= or =:transparent
+t=.
 
 * Examples:
 [[file:tests/babel-formatting.org][See this org file for examples of the different functionality and configurations.]]

--- a/ob-python-extras.el
+++ b/ob-python-extras.el
@@ -231,7 +231,7 @@ except:
                          (file-name-sans-extension (file-name-nondirectory buffer-file-name))
                          (concat ", transparent="
                                  (if transparent-header (if (equal (cdr transparent-header) "nil") "False" "True")
-                                   (if (and (boundp 'ob-python-extras/transparent-images) (not ob-python-extras/transparent-images)) "False" "True"))))))
+                                   (if (and (boundp 'ob-python-extras/transparent-images) ob-python-extras/transparent-images) "True" "False"))))))
       (apply orig body params args))))
 
 

--- a/ob-python-extras.el
+++ b/ob-python-extras.el
@@ -216,7 +216,7 @@ import os
 import sys
 sys.path.append(pymockbabel_script_location)
 import pymockbabel
-outputs_and_file_paths, output_types, list_writer = pymockbabel.setup(\"%s\")
+outputs_and_file_paths, output_types, list_writer = pymockbabel.setup(\"%s\"%s)
 with open(exec_file, 'r') as file:
     exec(compile(file.read(), '<org babel source block>', 'exec'))
 pymockbabel.display(outputs_and_file_paths, output_types, list_writer)
@@ -226,7 +226,8 @@ except:
     pass "
                          exec-file
                          pymockbabel-script-location
-                         (file-name-sans-extension (file-name-nondirectory buffer-file-name)))))
+                         (file-name-sans-extension (file-name-nondirectory buffer-file-name))
+                         (concat ", transparent=" (if (and (boundp 'ob-python-extras/transparent-images) (not ob-python-extras/transparent-images)) "False" "True")))))
       (apply orig body args))))
 
 

--- a/ob-python-extras.el
+++ b/ob-python-extras.el
@@ -204,10 +204,12 @@ finally:
 ;;;; Better output handling
 ;;;;; mix printing images and text
 
-(defun ob-python-extras/wrap-org-babel-execute-python-mock-plt (orig body &rest args)
+(defun ob-python-extras/wrap-org-babel-execute-python-mock-plt (orig body params &rest args)
   (let* ((exec-file (make-temp-file "execution-code"))
-         (pymockbabel-script-location (ob-python-extras/find-python-scripts-dir)))
-
+         (pymockbabel-script-location (ob-python-extras/find-python-scripts-dir))
+         (src-info (org-babel-get-src-block-info))
+         (headers (nth 2 src-info))
+         (transparent-header (assoc :transparent headers)))
     (with-temp-file exec-file (insert body))
     (let* ((body (format "\
 exec_file = \"%s\"
@@ -227,8 +229,10 @@ except:
                          exec-file
                          pymockbabel-script-location
                          (file-name-sans-extension (file-name-nondirectory buffer-file-name))
-                         (concat ", transparent=" (if (and (boundp 'ob-python-extras/transparent-images) (not ob-python-extras/transparent-images)) "False" "True")))))
-      (apply orig body args))))
+                         (concat ", transparent="
+                                 (if transparent-header (if (equal (cdr transparent-header) "nil") "False" "True")
+                                   (if (and (boundp 'ob-python-extras/transparent-images) (not ob-python-extras/transparent-images)) "False" "True"))))))
+      (apply orig body params args))))
 
 
 

--- a/python/pymockbabel.py
+++ b/python/pymockbabel.py
@@ -50,7 +50,7 @@ def stop_capturing(list_writer):
     sys.stderr = list_writer._stderr
 
 
-def mock_show(outputs_and_file_paths, output_types, org_babel_file_name):
+def mock_show(outputs_and_file_paths, output_types, org_babel_file_name, transparent):
     directory = os.path.join("plots", org_babel_file_name)
     os.makedirs(directory, exist_ok=True)
 
@@ -59,14 +59,14 @@ def mock_show(outputs_and_file_paths, output_types, org_babel_file_name):
         directory, f"plot_{timestamp}_{random.randint(0, 10000000)}.png"
     )
 
-    plt.savefig(file_path, transparent=True)
+    plt.savefig(file_path, transparent=transparent)
     outputs_and_file_paths.append(file_path)
     output_types.append("Image")
     plt.close()
     gc.collect()
 
 
-def setup(org_babel_file_name):
+def setup(org_babel_file_name, transparent):
     outputs_and_file_paths = []
     output_types = []
     if MATPLOTLIB_AVAILABLE:
@@ -77,6 +77,7 @@ def setup(org_babel_file_name):
                 outputs_and_file_paths=outputs_and_file_paths,
                 output_types=output_types,
                 org_babel_file_name=org_babel_file_name,
+                transparent=transparent
             ),
         ).start()
     list_writer = start_capturing(outputs_and_file_paths, output_types)

--- a/python/pymockbabel.py
+++ b/python/pymockbabel.py
@@ -59,7 +59,7 @@ def mock_show(outputs_and_file_paths, output_types, org_babel_file_name):
         directory, f"plot_{timestamp}_{random.randint(0, 10000000)}.png"
     )
 
-    plt.savefig(file_path)
+    plt.savefig(file_path, transparent=True)
     outputs_and_file_paths.append(file_path)
     output_types.append("Image")
     plt.close()


### PR DESCRIPTION
### Changelog
- DONE use matplotlib to save images with transparency by default
- DONE variable to change default setting, boolean `ob-python-extras/transparent-images`, e.g.:
```emacs-lisp
(use-package! ob-python-extras
  :config (setq ob-python-extras/transparent-images nil))
```
- DONE per-org-source-block override via `:transparent t` or `:transparent` forcing transparency and `:transparent nil` forcing non-transparency
- DONE update readme

### Known issues
inlined images do not to respect the user's frames' `alpha-background`.  This seems to be a limitation of emacs at present. See for example: 
![image](https://github.com/user-attachments/assets/4152621a-b8e0-4e44-a313-14c947ec4e0d)
