### PR TITLE
Added code formatting with black or ruff

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -151,8 +151,8 @@ This default, in turn, can be overridden at the org-src-block level with
 ** Setting up code formatting
 
 The code formatters =ruff= and =black= are supported. Set the variable
-=ob-python-extras-formatter= to "ruff" or "black" and then execute =M-x
-ob-python-extras-format= when in a python code block (or source edit buffer).
+=ob-python-extras-formatter= to "ruff" or "black" and then execute
+=M-x ob-python-extras-format= when in a python code block (or source edit buffer).
 The formatter searches for its configuration options as usual, with the search
 path starting at the directory containing the org file. The default
 configurations can be overridden by specifying the file in the variable

--- a/Readme.org
+++ b/Readme.org
@@ -142,11 +142,26 @@ Then blocks will be sent automatically when a traceback is detected in the respo
 #+end_src
 
 ** Matplotlib image transparency
+
 Matplotlib is configured to save and display images without transparency by
-default. The default can be changed with ~(setq
-ob-python-extras/transparent-images t)~. This default, in turn, can be
-overridden at the org-src-block level with =:transparent nil= or =:transparent
-t=.
+default. The default can be changed with =(setq ob-python-extras/transparent-images t)=.
+This default, in turn, can be overridden at the org-src-block level with
+=:transparent nil= or =:transparent t=.
+
+** Setting up code formatting
+
+The code formatters =ruff= and =black= are supported. Set the variable
+=ob-python-extras-formatter= to "ruff" or "black" and then execute =M-x
+ob-python-extras-format= when in a python code block (or source edit buffer).
+The formatter searches for its configuration options as usual, with the search
+path starting at the directory containing the org file. The default
+configurations can be overridden by specifying the file in the variable
+=ob-python-extras-formatter-config=.
+
+To format code automatically upon execution of source code blocks, add a hook:
+#+begin_src emacs-lisp
+(add-hook 'org-babel-after-execute-hook 'ob-python-extras-format)
+#+end_src
 
 * Examples:
 [[file:tests/babel-formatting.org][See this org file for examples of the different functionality and configurations.]]

--- a/ob-python-extras.el
+++ b/ob-python-extras.el
@@ -557,13 +557,14 @@ The formatter uses either black or ruff according to the variable
 ob-python-extras-formatter."
   (let* ((code-to-format (org-element-property :value (org-element-at-point)))
          (temp-file
-          (make-temp-file
-           (concat (file-name-directory (buffer-file-name)) ".ob-python-extras-format")
-           nil nil code-to-format))
+          (let ((inhibit-message t)
+                (message-log-max nil))
+            (make-temp-file
+             (concat (file-name-directory (buffer-file-name)) ".ob-python-extras-format")
+             nil nil code-to-format)))
          (content-area (org-src--contents-area (org-element-at-point)))
          (beg (car content-area))
          (end (cadr content-area)))
-    (message "LOG: %s" (ob-python-extras--get-formatter-args temp-file))
     (apply #'async-start-process
            "ob-python-extras-format-process"
            ob-python-extras-formatter
@@ -589,8 +590,7 @@ TEMP-FILE-NAME."
   (with-current-buffer src-edit-buffer
     (insert-file-contents temp-file-name nil nil nil t))
   (when (file-exists-p temp-file-name)
-    (delete-file temp-file-name))
-  (message "Formatted org-src-edit-buffer"))
+    (delete-file temp-file-name)))
 
 (defun ob-python-extras--format-src-block-callback (temp-file-name src-block-buffer beg end _process-obj)
   "Callback function to replace org source block contents with formatted code.
@@ -602,8 +602,7 @@ SRC-BLOCK-BUFFER with it. Finally, deletes TEMP-FILE-NAME."
     (narrow-to-region beg end)
     (insert-file-contents temp-file-name nil nil nil t))
   (when (file-exists-p temp-file-name)
-    (delete-file temp-file-name))
-  (message "Formatted org-src-block"))
+    (delete-file temp-file-name)))
 
 ;;; Load other packages
 

--- a/ob-python-extras.el
+++ b/ob-python-extras.el
@@ -524,5 +524,26 @@ In regular org-mode, tries to view image or executes normal C-c C-c."
          (this-dir (file-name-directory this-file)))
     (load (expand-file-name "ob-python-extras-alerts" this-dir))))
 
+
+;; TODO note there are also inline source code blocks?
+(defun ob-python-extras-format-ruff ()
+  (interactive)
+  (when (member 'org-src-mode local-minor-modes)
+    (let ((created-temp-file
+           (make-temp-file
+            (concat (file-name-as-directory (org-babel-temp-directory)) "ob-python-extras-format-ruff-")
+            nil
+            nil
+            (buffer-string))))
+      (async-start-process "ruff"
+                           "ruff"
+                           (apply-partially 'ob-python-extras--format-ruff-callback created-temp-file (current-buffer))
+                           "format" created-temp-file))))
+
+(defun ob-python-extras--format-ruff-callback (temp-file-name src-edit-buffer process-obj)
+  (message "formatted code: %s" temp-file-name)
+  (with-current-buffer src-edit-buffer
+    (insert-file-contents temp-file-name nil nil nil t)))
+
 (provide 'ob-python-extras)
 ;;; ob-python-extras.el ends here

--- a/ob-python-extras.el
+++ b/ob-python-extras.el
@@ -509,19 +509,6 @@ In regular org-mode, tries to view image or executes normal C-c C-c."
            (script-path (concat ob-python-extras-dir "bashscripts/convert_org_to_ipynb.sh" )))
       (compile (concat "cd " current-dir " && "script-path)))))
 
-(defun ob-python-extras-format-ruff ()
-  (interactive)
-  (when (member 'org-src-mode local-minor-modes)
-    (let ((created-temp-file
-           (make-temp-file
-            (concat (file-name-as-directory (org-babel-temp-directory)) "ob-python-extras-format-ruff-")
-            nil
-            nil
-            (buffer-string))))
-      (async-start-process "ob-python-extras-format-process"
-                           "ruff"
-                           (apply-partially 'ob-python-extras-format-callback created-temp-file (current-buffer))
-                           "format" created-temp-file))))
 
 (defun ob-python-extras-format-buffer-callback (temp-file-name src-edit-buffer process-obj)
   (with-current-buffer src-edit-buffer


### PR DESCRIPTION
Use `M-x ob-python-extras-format` to format code blocks (supports ruff and black).

- DONE format src-edit buffers
- DONE format src-blocks outside of src-edit buffers
- DONE format using black or ruff, optionally via
```emacs-lisp
(use-package! ob-python-extras
  :config
  (setq ob-python-extras-formatter "ruff"))
```
- DONE do nothing if code block is not lang python
- DONE learn some emacs-lisp to consolidate the ruff and black functions (ruff takes "format" as the first argument whereas black takes no arguments)
- DONE formatter can be set to run on code block execution by modifying the appropriate hook `(add-hook 'org-babel-after-execute-hook 'ob-python-extras-format)`
- DONE ensure that formatters are using their configs (e.g. checking pyproject.toml/ruff.toml/etc. if necessary)
- DONE remove "Wrote /tmp/babel-RRecW4/ob-python-extras-formatOBqumF" messages every time format is run
- DONE add documentation to the README